### PR TITLE
🎉 init - tela de meus posts feita close #23

### DIFF
--- a/frontend-gda/src/app/Components/MeusPostsCard.tsx
+++ b/frontend-gda/src/app/Components/MeusPostsCard.tsx
@@ -1,0 +1,86 @@
+// components/MeusPostsCard.tsx
+"use client";
+
+import React from "react";
+import MiniCard from "./UI/MiniCard";
+import { Search } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+type Props = {
+  children?: React.ReactNode;
+};
+
+export default function MeusPostsCard({ children }: Props) {
+  const router = useRouter();
+  return (
+    <div className="relative w-[50vw] h-[800px] max-h-[80vh]  p-6 rounded-xl
+                    bg-white/10 backdrop-blur-md border border-white/30
+                    shadow-lg">
+
+    {/* Search */}
+<div className="w-[30vw] mb-6 px-2"> 
+      <label htmlFor="search" className="sr-only">Pesquisar</label>
+
+      <div className="relative w-full">
+        {/* Ícone Lucide Search */}
+        <span className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
+          <Search className="w-5 h-5 text-gray-500" />
+        </span>
+
+        {/* Input */}
+        <input
+          id="search"
+          placeholder="Pesquisar..."
+          className="
+            w-full py-3 pl-12 pr-4
+            rounded-full bg-white/90
+            text-gray-800 placeholder-gray-400
+            shadow-sm
+            focus:outline-none focus:ring-2 focus:ring-pink-400
+            transition
+          "
+        />
+      </div>
+    </div>
+
+
+      {/* White area onde ficam os cards (com scroll) */}
+      <div
+        className="bg-white rounded-lg p-6 h-[540px] w-auto overflow-y-auto
+                   shadow-inner border border-white/20"
+      >
+        {/* 
+          Aqui é onde você insere os cards.
+          Use {children} para renderizar os cards vindos de fora.
+          Se quiser testar sem cards, eu deixei um "skeleton card" de exemplo abaixo.
+        */}
+        <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          {children ? (
+            children
+          ) : (
+                      <><><MiniCard variant="editor" status="privado" /><MiniCard variant="editor" status="privado" /><MiniCard variant="editor" status="privado" /><MiniCard variant="editor" status="privado" /></><><MiniCard variant="editor" status="privado" /><MiniCard variant="editor" status="privado" /><MiniCard variant="editor" status="privado" /><MiniCard variant="editor" status="privado" /></></>
+
+
+
+
+
+
+
+          )}
+        </div>
+      </div>
+
+   <div className="">
+      {/* Botão flutuante */}
+      <button
+        type="button"
+        onClick={() => router.push("/Editor")} 
+        className="absolute right-8 bottom-8 bg-pink-500 hover:bg-pink-600 text-white font-semibold
+                   px-6 py-3 rounded-full shadow-lg focus:outline-none focus:ring-4 focus:ring-pink-300"
+      >
+        Criar novo post
+      </button>
+    </div>
+    </div>
+  );
+}

--- a/frontend-gda/src/app/Components/UI/MiniCard.tsx
+++ b/frontend-gda/src/app/Components/UI/MiniCard.tsx
@@ -1,6 +1,14 @@
-import { Calendar, Heart, MessageCircle } from "lucide-react";
+import { Calendar, Eye, Pencil, Trash2, Heart, MessageCircle } from "lucide-react";
 
-export default function MiniCard() {
+interface MiniCardProps {
+  variant?: "default" | "editor";
+  status?: "publico" | "privado"; 
+}
+
+export default function MiniCard({
+  variant = "default",
+  status = "publico",
+}: MiniCardProps) {
   return (
     <div
       className="
@@ -11,8 +19,6 @@ export default function MiniCard() {
         flex flex-col 
         py-4 px-3 
         shadow-xl
-
-        /* animações */
         transition-all duration-200 
         hover:scale-105 
         active:scale-95 
@@ -20,14 +26,33 @@ export default function MiniCard() {
         cursor-pointer
       "
     >
-      {/* Header / Tema */}
-      <div className="flex justify-end w-full mb-3">
+
+      {/* ─────────────────────────────────────────────
+          HEADER (Tema + status quando estiver no modo Editor)
+      ───────────────────────────────────────────── */}
+      <div className="flex justify-between items-center w-full mb-3">
+
+        {/* STATUS — apenas na versão Editor */}
+        {variant === "editor" && (
+          <span
+            className={`
+              text-sm font-semibold
+              ${status === "publico" ? "text-pink-600" : "text-black/50"}
+            `}
+          >
+            {status === "publico" ? "Público" : "Privado"}
+          </span>
+        )}
+
+        {/* TAG TEMA (sempre aparece) */}
         <div className="bg-[#8F005D] text-white px-4 py-1 rounded-full text-sm">
           Tema
         </div>
       </div>
 
-      {/* Thumbnail */}
+      {/* ─────────────────────────────────────────────
+          THUMBNAIL
+      ───────────────────────────────────────────── */}
       <div
         className="
           bg-[#CCCCCC] 
@@ -40,11 +65,11 @@ export default function MiniCard() {
         <p className="text-black/30 text-sm">Thumbnail</p>
       </div>
 
-      {/* Título + Data */}
+      {/* ─────────────────────────────────────────────
+          TÍTULO + DATA
+      ───────────────────────────────────────────── */}
       <div className="text-center mt-3 w-full">
-        <p className="font-semibold text-black text-lg">
-          Título do Post
-        </p>
+        <p className="font-semibold text-black text-lg">Título do Post</p>
 
         <div className="flex justify-center items-center gap-2 text-black/40 text-sm mt-1">
           <Calendar size={16} />
@@ -52,18 +77,41 @@ export default function MiniCard() {
         </div>
       </div>
 
-      {/* Likes / Comments */}
-      <div className="flex justify-between items-center w-full mt-4">
-        <div className="flex items-center gap-1 text-black/70">
-          <Heart size={20} />
-          <span>10</span>
-        </div>
+      {/* ─────────────────────────────────────────────
+          FOOTER (Dependendo do modo)
+      ───────────────────────────────────────────── */}
 
-        <div className="flex items-center gap-1 text-black/70">
-          <MessageCircle size={20} />
-          <span>10</span>
+      {/* MODO DEFAULT — Likes e Comentários */}
+      {variant === "default" && (
+        <div className="flex justify-between items-center w-full mt-4">
+          <div className="flex items-center gap-1 text-black/70">
+            <Heart size={20} />
+            <span>10</span>
+          </div>
+
+          <div className="flex items-center gap-1 text-black/70">
+            <MessageCircle size={20} />
+            <span>10</span>
+          </div>
         </div>
-      </div>
+      )}
+
+      {/* MODO EDITOR — Editar, Visualizar, Excluir */}
+      {variant === "editor" && (
+        <div className="flex justify-between items-center w-full mt-4 px-2">
+          <button className="text-black/70 hover:text-black">
+            <Pencil size={20} />
+          </button>
+
+          <button className="text-black/70 hover:text-black">
+            <Eye size={20} />
+          </button>
+
+          <button className="text-black/70 hover:text-red-600">
+            <Trash2 size={20} />
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend-gda/src/app/MeusPosts/page.tsx
+++ b/frontend-gda/src/app/MeusPosts/page.tsx
@@ -1,0 +1,21 @@
+import MeusPostsCard from "../Components/MeusPostsCard";
+
+export default function MeusPosts(){
+    return(
+        <div className="flex flex-col justify-center items-center" style={{
+        minHeight: '100vh',
+        paddingBottom: '50px',
+        backgroundImage: "url('/background2.png') ",
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundAttachment: 'scroll',
+      }} >
+        <div>
+            <h1 className="text-white text-2xl p-4">Meus Posts</h1>
+        </div>
+        <div>
+            <MeusPostsCard></MeusPostsCard>
+        </div>
+      </div>
+    )
+}


### PR DESCRIPTION
Criada a nova página Meus Posts, incluindo estrutura principal com fundo blur, área branca interna com scroll vertical e botão flutuante para criação de novos posts.

Implementado campo de pesquisa com ícone de lupa utilizando Lucide React, agora alinhado corretamente ao início do container principal.

Criado componente MiniCard com duas versões:

Default – contendo thumbnail, título, data, likes e comentários.

Editor – adicionados os ícones de Editar, Visualizar e Excluir, além do rótulo que indica se o post é Público ou Privado (privado com opacidade reduzida).

Adicionada animação de hover, click e sombras no MiniCard para melhorar a experiência do usuário.

Botão “Criar novo post” agora redireciona para a página Editor ao ser clicado.

Estrutura base dos cards criada para futura listagem dinâmica.